### PR TITLE
Unify local DNS behavior of Cgo and pure Go resolver

### DIFF
--- a/transport_local.go
+++ b/transport_local.go
@@ -64,7 +64,7 @@ func (t *LocalTransport) Lookup(ctx context.Context, domain string, strategy Dom
 	case DomainStrategyUseIPv6:
 		network = "ip6"
 	}
-	addrs, err := t.resolver.LookupNetIP(context.Background(), network, domain)
+	addrs, err := t.resolver.LookupNetIP(ctx, network, domain)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
SagerNet/sing-box#1681

For Go resolver, `local` DNS must set a `detour`, its traffic will go through sing-box and destination will be incorrectly overridden. This PR make Go resolver's traffic ignore `detour` and not go through sing-box, just like Cgo resolver's behavior.

P.S. On Windows, Cgo resolver doesn't rely on the Cgo tool, and resolver prefers Cgo to Go, so even if compiling with CGO_ENABLED=0, sing-box will still use the Cgo resolver.