### PR TITLE
fix closing udp conn on query ctx cancel

### DIFF
--- a/transport_udp.go
+++ b/transport_udp.go
@@ -159,7 +159,6 @@ func (t *UDPTransport) exchange(ctx context.Context, message *dns.Msg) (*dns.Msg
 	case <-conn.ctx.Done():
 		return nil, E.Errors(conn.err, conn.ctx.Err())
 	case <-ctx.Done():
-		conn.Close()
 		return nil, ctx.Err()
 	}
 }


### PR DESCRIPTION
When a single dns query's ctx is cancelled due to any reason, the entire udp dnsConn is closed which causes any other query waiting on this connection for response to fail. This pr fixes this issue.