### PR TITLE
fix QUIC stream close

### DIFF
--- a/quic/transport_quic.go
+++ b/quic/transport_quic.go
@@ -153,12 +153,12 @@ func (t *Transport) exchange(ctx context.Context, message *mDNS.Msg, conn quic.C
 	if err != nil {
 		return nil, err
 	}
-	defer stream.Close()
-	defer stream.CancelRead(0)
 	_, err = stream.Write(buffer.Bytes())
 	if err != nil {
+		stream.Close()
 		return nil, err
 	}
+	stream.Close()
 	buffer.Reset()
 	_, err = buffer.ReadFullFrom(stream, 2)
 	if err != nil {


### PR DESCRIPTION
Current implementation does not work with some public DoQ servers (e.g. `quic://dns.nextdns.io`)

https://datatracker.ietf.org/doc/html/rfc9250#section-4.2-6

- The client MUST send the DNS query over the selected stream and MUST indicate through the STREAM FIN mechanism that no further data will be sent on that stream.
- Servers MAY defer processing of a query until the STREAM FIN has been indicated on the stream selected by the client.